### PR TITLE
fix null pointer expection if no value is provided

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/hawkv6/hawkwing
 
-go 1.21
+go 1.21.0
+
 toolchain go1.22.2
 
 require (

--- a/pkg/entities/path_result.go
+++ b/pkg/entities/path_result.go
@@ -26,10 +26,18 @@ func UnmarshalPathResult(pr *api.PathResult) *PathResult {
 	for _, intent := range pr.Intents {
 		intentValues := make([]IntentValue, 0, len(intent.Values))
 		for _, val := range intent.Values {
+			numberValue := int32(0)
+			stringValue := ""
+			if val.NumberValue != nil {
+				numberValue = *val.NumberValue
+			}
+			if val.StringValue != nil {
+				stringValue = *val.StringValue
+			}
 			intentValues = append(intentValues, IntentValue{
 				IntentValueType: types.IntentValueType(val.Type),
-				NumberValue:     *val.NumberValue,
-				StringValue:     *val.StringValue,
+				NumberValue:     numberValue,
+				StringValue:     stringValue,
 			})
 		}
 		intents = append(intents, Intent{


### PR DESCRIPTION
# Pull Request Template

## Description
The application breaks if there is no number but a string value provided:

```
root@HOST-A:/# ./hawkwing client -i eth1 --config sfc-config.yaml
==================INFO==================
Hawkwing is running in controller mode.
========================================
Client started on interface "eth1"
Press Ctrl-C to exit and remove the program
time="2024-08-28T08:37:29Z" level=info msg="connected to [2001:172:20:1::41]:10000" subsystem=go-messaging
time="2024-08-28T08:37:29Z" level=info msg="start synchronization process" subsystem=go-syncer
time="2024-08-28T08:37:29Z" level=info msg="fetching all needed intent details" subsystem=go-syncer
time="2024-08-28T08:37:29Z" level=info msg="requested intent details for 2001:db8:b::10" subsystem=go-syncer
time="2024-08-28T08:37:29Z" level=info msg="sent intent request for 2001:db8:b::10" subsystem=go-messaging
time="2024-08-28T08:37:29Z" level=info msg="received intent result for 2001:db8:b::10" subsystem=go-messaging
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x94cc8e]

goroutine 146 [running]:
github.com/hawkv6/hawkwing/pkg/entities.UnmarshalPathResult(...)
	/home/runner/work/hawkwing/hawkwing/pkg/entities/path_result.go:31
github.com/hawkv6/hawkwing/pkg/messaging.(*MessagingAdapter).Start.func2()
	/home/runner/work/hawkwing/hawkwing/pkg/messaging/adapter.go:27 +0x30e
created by github.com/hawkv6/hawkwing/pkg/messaging.(*MessagingAdapter).Start in goroutine 7
	/home/runner/work/hawkwing/hawkwing/pkg/messaging/adapter.go:24 +0x96

```

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

Before submitting your PR, please review and confirm the following:

- [X] I have reviewed the [contributing guidelines](./CONTRIBUTING.md).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.

